### PR TITLE
Refactor action creators - Get pinned city extended working

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -3,52 +3,74 @@ import fetch from 'isomorphic-fetch';
 const apiKey = '9b9ce697dc74009c';
 const weatherURL = `https://api.wunderground.com/api/${apiKey}`;
 
-export const receiveCurrentWeatherByGPS = (weatherInfo) => {
+export const receiveCurrentLocalWeather = (cityInfo, weatherInfo) => {
+    let payload = Object.assign(cityInfo.location, weatherInfo);
     return {
-        type: 'CURRENT_LOCAL_WEATHER_GPS',
-        currentLocalForecast: weatherInfo
+        type: 'CURRENT_LOCAL_WEATHER',
+        currentLocalForecast: payload
     };
 };
 
-export const receiveCurrentExtendedForecast = (geoLocation, weatherInfo) => {
-    let payload = Object.assign(geoLocation.location, weatherInfo.forecast.txt_forecast);
+export const fetchCurrentLocalWeather = (cityInfo) => {
+    const zipcode = cityInfo.location.zip;
+    const currentWeatherByZip = `${weatherURL}/conditions/q/${zipcode}.json`;
+
+    return dispatch => {
+        return fetch(currentWeatherByZip)
+            .then(response => response.json())
+            .catch(err => console.log(err))
+            .then(weatherInfo => dispatch(receiveCurrentLocalWeather(cityInfo, weatherInfo)));
+    };
+};
+
+export const receiveLocalExtendedForecast = (cityInfo, weatherInfo) => {
+    let payload = Object.assign(cityInfo.location, weatherInfo.forecast.txt_forecast);
     return {
         type: 'CURRENT_EXTENDED_FORECAST',
         extendedForecast: payload
     };
 };
 
-export const fetchMyLocation = (position, weatherInfo, method) => {
-    let geoLocationURL = `${weatherURL}/geolookup/q/${position.coords.latitude},${position.coords.longitude}.json`;
-    return dispatch => {
-        fetch(geoLocationURL)
-            .then(response => response.json())
-            .then(geoLocation => dispatch(method(geoLocation, weatherInfo)));
-    };
-}
-
-export const fetchCurrentWeatherByGPS = (position) => {
-    let weatherURLbyGPS = `${weatherURL}/conditions/q/${position.coords.latitude},${position.coords.longitude}.json`;
+export const fetchLocalExtendedForecast = (cityInfo) => {
+    let zipcode = cityInfo.location.zip;
+    let extendedByZip = `${weatherURL}/forecast/q/${zipcode}.json`;
 
     return dispatch => {
-        return fetch(weatherURLbyGPS)
+        return fetch(extendedByZip)
             .then(response => response.json())
-            .then(jsonResponse => dispatch(receiveCurrentWeatherByGPS(jsonResponse)));
+            .catch(err => console.log(err))
+            .then(weatherInfo => dispatch(receiveLocalExtendedForecast(cityInfo, weatherInfo)));
     };
 };
 
-export const fetchLocalExtendedForecast = (position) => {
-    let weatherURLExtendedForecast = `${weatherURL}/forecast/q/${position.coords.latitude},${position.coords.longitude}.json`;
-
-    return dispatch => {
-        return fetch(weatherURLExtendedForecast)
-            .then(response => response.json())
-            .then(weatherInfo => dispatch(fetchMyLocation(position, weatherInfo, receiveCurrentExtendedForecast)));
+export const receivePinnedCityExtended = (weatherInfo, cityInfo, zipcode) => {
+    debugger;
+    let payload = Object.assign(weatherInfo, {
+        zipcode,
+        id: Date.now()
+    });
+    return {
+        type: 'PINNED_CITY_EXTENDED_FORECAST',
+        payload
     };
 };
 
-export const receiveCurrentPinnedCityWeather = (pinnedCityWeather, cityInfo, zipcode) => {
-    let payload = Object.assign(cityInfo, { zipcode, id: Date.now() }, pinnedCityWeather);
+export const fetchPinnedCityExtended = (cityInfo, zipcode) => {
+    let weatherURLbyZip = `${weatherURL}/forecast/q/${zipcode}.json`;
+    debugger;
+    return dispatch => {
+        return fetch(weatherURLbyZip)
+            .then(response => response.json())
+            .catch(err => console.log('an error occurred', err))
+            .then(pinnedCityExtended => dispatch(receivePinnedCityExtended(pinnedCityExtended, cityInfo, zipcode)));
+    };
+};
+
+export const receivePinnedCityWeather = (pinnedCityWeather, cityInfo, zipcode) => {
+    let payload = Object.assign(cityInfo, {
+        zipcode,
+        id: Date.now()
+    }, pinnedCityWeather);
     return {
         type: 'PINNNED_CITY_CURRENT_WEATHER',
         payload
@@ -57,20 +79,11 @@ export const receiveCurrentPinnedCityWeather = (pinnedCityWeather, cityInfo, zip
 
 export const fetchPinnedCityWeather = (cityInfo, zipcode) => {
     let weatherURLbyZip = `${weatherURL}/conditions/q/${zipcode}.json`;
-
+    debugger;
     return dispatch => {
         return fetch(weatherURLbyZip)
             .then(response => response.json())
-            .then(pinnedCityWeather => dispatch(receiveCurrentPinnedCityWeather(pinnedCityWeather, cityInfo, zipcode)));
-    };
-};
-
-export const fetchPinnedCityInfo = (zipcode) => {
-    let zipURL = `http://ZiptasticAPI.com/${zipcode}`;
-
-    return (dispatch) => {
-        return fetch(zipURL)
-            .then(response => response.json())
-            .then(cityInfo => dispatch(fetchPinnedCityWeather(cityInfo, zipcode)));
+            .then(pinnedCityWeather => dispatch(receivePinnedCityWeather(pinnedCityWeather, cityInfo, zipcode)))
+            .catch(err => console.log('an error occurred', err));
     };
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -39,51 +39,45 @@ export const fetchLocalExtendedForecast = (cityInfo) => {
         return fetch(extendedByZip)
             .then(response => response.json())
             .catch(err => console.log(err))
-            .then(weatherInfo => dispatch(receiveLocalExtendedForecast(cityInfo, weatherInfo)));
+            .then(weatherInfo => dispatch(
+                receiveLocalExtendedForecast(cityInfo, weatherInfo)));
     };
 };
 
-export const receivePinnedCityExtended = (weatherInfo, cityInfo, zipcode) => {
-    debugger;
-    let payload = Object.assign(weatherInfo, {
-        zipcode,
-        id: Date.now()
-    });
+export const receivePinnedCityExtendedForecast = (weatherInfo, cityInfo, zipcode) => {
+    let payload = Object.assign(cityInfo, weatherInfo.forecast, { zipcode, id: Date.now() });
     return {
         type: 'PINNED_CITY_EXTENDED_FORECAST',
         payload
     };
 };
 
-export const fetchPinnedCityExtended = (cityInfo, zipcode) => {
+export const fetchPinnedCityExtendedForecast = (cityInfo, zipcode) => {
     let weatherURLbyZip = `${weatherURL}/forecast/q/${zipcode}.json`;
-    debugger;
     return dispatch => {
         return fetch(weatherURLbyZip)
             .then(response => response.json())
             .catch(err => console.log('an error occurred', err))
-            .then(pinnedCityExtended => dispatch(receivePinnedCityExtended(pinnedCityExtended, cityInfo, zipcode)));
+            .then(weatherInfo => dispatch(
+                receivePinnedCityExtendedForecast(weatherInfo, cityInfo, zipcode)));
     };
 };
 
-export const receivePinnedCityWeather = (pinnedCityWeather, cityInfo, zipcode) => {
-    let payload = Object.assign(cityInfo, {
-        zipcode,
-        id: Date.now()
-    }, pinnedCityWeather);
+export const receivePinnedCityCurrentWeather = (pinnedCityWeather, cityInfo, zipcode) => {
+    let payload = Object.assign(cityInfo, { zipcode, id: Date.now() }, pinnedCityWeather);
     return {
         type: 'PINNNED_CITY_CURRENT_WEATHER',
         payload
     };
 };
 
-export const fetchPinnedCityWeather = (cityInfo, zipcode) => {
+export const fetchPinnedCityCurrentWeather = (cityInfo, zipcode) => {
     let weatherURLbyZip = `${weatherURL}/conditions/q/${zipcode}.json`;
-    debugger;
     return dispatch => {
         return fetch(weatherURLbyZip)
             .then(response => response.json())
-            .then(pinnedCityWeather => dispatch(receivePinnedCityWeather(pinnedCityWeather, cityInfo, zipcode)))
-            .catch(err => console.log('an error occurred', err));
+            .catch(err => console.log('an error occurred', err))
+            .then(weatherInfo => dispatch(
+                receivePinnedCityCurrentWeather(weatherInfo, cityInfo, zipcode)));
     };
 };

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,8 @@
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { fetchCurrentWeatherByGPS, fetchLocalExtendedForecast } from '../actions/index';
+import { fetchCurrentLocalWeather, fetchLocalExtendedForecast } from '../actions/index';
+import { fetchLocationByPosition } from '../helpers';
 
 import HeaderContainer from '../containers/HeaderContainer';
 
@@ -10,7 +11,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({fetchCurrentWeatherByGPS, fetchLocalExtendedForecast  }, dispatch);
+  return bindActionCreators({fetchCurrentLocalWeather, fetchLocalExtendedForecast  }, dispatch);
 };
 
 class App extends Component {
@@ -21,8 +22,12 @@ class App extends Component {
             return;
         }
         navigator.geolocation.getCurrentPosition((position) => {
-            this.props.fetchCurrentWeatherByGPS(position);
-            this.props.fetchLocalExtendedForecast(position);
+            fetchLocationByPosition(position)
+            .then((cityInfo) => {
+                this.props.fetchCurrentLocalWeather(cityInfo);
+                this.props.fetchLocalExtendedForecast(cityInfo);
+            })
+            .catch(err => console.log(err));
         });
     }
 

--- a/src/components/ExtendedForecast.js
+++ b/src/components/ExtendedForecast.js
@@ -12,14 +12,14 @@ const ExtendedForecast = ({ExtendedForecast, zipCode}) => {
 
       <section className="extended-container">
           {ExtendedForecast.forecastday ?
-            <div>
-            <h1>EXTENDED FORECAST</h1>
-            <h1>City: {ExtendedForecast.city}</h1>
-            <br/>
-            <ul>
-            { ExtendedForecast.forecastday.map((day) => <li key={day.period}> <img src={day.icon_url} alt="weather icon" /> {day.title} -- {day.fcttext}</li>)}
-            </ul>
-            </div>
+            <article>
+              <h1>EXTENDED FORECAST</h1>
+              <h1>City: {ExtendedForecast.city}</h1>
+              <br/>
+              <ul>
+                { ExtendedForecast.forecastday.map((day) => <li key={day.period}> <img src={day.icon_url} alt="weather icon" /> {day.title} -- {day.fcttext}</li>)}
+              </ul>
+            </article>
           : <p>Fetching Extended forecast...</p>}
       </section>
     </div>

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -24,7 +24,8 @@ const Home = ({pinnedCityList}) => {
       </section>
       <Link
         to="/Settings"
-        className="edit-cities">
+        className="edit-cities"
+        >
         Edit Pinned Cities &#10163;
       </Link>
     </div>

--- a/src/components/PinnedCityExtended.js
+++ b/src/components/PinnedCityExtended.js
@@ -1,21 +1,23 @@
 import React from 'react';
 
-const PinnedCityExtended = ({
-    zipcode,
-    weatherInfo
-}) => {
-    debugger;
+const PinnedCityExtended = ({ zipcode, weatherInfo }) => {
     return (
-        <article>
+        <section>
             {Object.keys(weatherInfo).length ?
-                <ul>
-                    <li>City: {weatherInfo.city} </li>
-                    <li>Temp: {Math.round(weatherInfo.current_observation.temp_f)} </li>
-                    <li>Outlook: {weatherInfo.current_observation.weather} </li>
-                    <li>Humidity: {weatherInfo.current_observation.relative_humidity}</li>
-                </ul>
+                <article>
+                    <ul>
+                        <li>City: {weatherInfo.city} </li>
+                        <li>Current temp: {Math.round(weatherInfo.current_observation.temp_f)} </li>
+                        <li>Current Outlook: {weatherInfo.current_observation.weather} </li>
+                    </ul>
+                    <h1>Extended Forecast</h1>
+                    <ul>
+                        {weatherInfo.txt_forecast &&
+                            weatherInfo.txt_forecast.forecastday.map((day) => <li key={day.period}> <img src={day.icon_url} alt="weather icon" /> {day.title} -- {day.fcttext}</li>)}
+                    </ul>
+                </article>
                 : <p> Fetching forecast... </p>}
-        </article>
+        </section>
     )
 };
 

--- a/src/components/PinnedCityExtended.js
+++ b/src/components/PinnedCityExtended.js
@@ -4,7 +4,7 @@ const PinnedCityExtended = ({
     zipcode,
     weatherInfo
 }) => {
-    
+    debugger;
     return (
         <article>
             {Object.keys(weatherInfo).length ?

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
+import { fetchLocationByZip } from '../helpers';
 
 const Settings = ({ pinnedCities, onSubmit }) => {
   let input;
@@ -15,7 +16,9 @@ const Settings = ({ pinnedCities, onSubmit }) => {
           className="add-city-container"
           onSubmit={ (e) => {
             e.preventDefault();
-            onSubmit(input.value);
+            const zipcode = input.value;
+            fetchLocationByZip(zipcode)
+            .then(cityInfo => onSubmit(cityInfo, zipcode));
             input.value=('');
           }}
         >

--- a/src/containers/PinnedCityExtendedContainer.js
+++ b/src/containers/PinnedCityExtendedContainer.js
@@ -5,7 +5,6 @@ const mapStateToProps = (state, ownProps) => {
   let zipcode = ownProps.params.zip;
   let myWeather = state.pinnedCityExtendedReducer.find(city => zipcode === city.zipcode);
 
-  debugger;
   return {
     weatherInfo: myWeather,
     zipcode

--- a/src/containers/PinnedCityExtendedContainer.js
+++ b/src/containers/PinnedCityExtendedContainer.js
@@ -3,13 +3,13 @@ import PinnedCityExtended from '../components/PinnedCityExtended';
 
 const mapStateToProps = (state, ownProps) => {
   let zipcode = ownProps.params.zip;
-  let myWeather = state.pinnedCityReducer.find(city => zipcode === city.zipcode);
+  let myWeather = state.pinnedCityExtendedReducer.find(city => zipcode === city.zipcode);
+
+  debugger;
   return {
     weatherInfo: myWeather,
     zipcode
   };
 };
-
-
 
 export default connect(mapStateToProps)(PinnedCityExtended);

--- a/src/containers/SettingsContainer.js
+++ b/src/containers/SettingsContainer.js
@@ -1,13 +1,14 @@
 import { connect } from 'react-redux';
-import { fetchPinnedCityInfo } from '../actions';
+import { fetchPinnedCityWeather, fetchPinnedCityExtended } from '../actions';
 import Settings from '../components/Settings';
 
 const mapStateToProps = (state) => ({ pinnedCities: state.pinnedCityReducer });
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    onSubmit: (zipcode) => {
-      dispatch(fetchPinnedCityInfo(zipcode));
+    onSubmit: (cityInfo, zipcode) => {
+      dispatch(fetchPinnedCityWeather(cityInfo, zipcode));
+      dispatch(fetchPinnedCityExtended(cityInfo, zipcode));
     }
   };
 };

--- a/src/containers/SettingsContainer.js
+++ b/src/containers/SettingsContainer.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { fetchPinnedCityWeather, fetchPinnedCityExtended } from '../actions';
+import { fetchPinnedCityCurrentWeather, fetchPinnedCityExtendedForecast } from '../actions';
 import Settings from '../components/Settings';
 
 const mapStateToProps = (state) => ({ pinnedCities: state.pinnedCityReducer });
@@ -7,8 +7,8 @@ const mapStateToProps = (state) => ({ pinnedCities: state.pinnedCityReducer });
 const mapDispatchToProps = (dispatch) => {
   return {
     onSubmit: (cityInfo, zipcode) => {
-      dispatch(fetchPinnedCityWeather(cityInfo, zipcode));
-      dispatch(fetchPinnedCityExtended(cityInfo, zipcode));
+      dispatch(fetchPinnedCityCurrentWeather(cityInfo, zipcode));
+      dispatch(fetchPinnedCityExtendedForecast(cityInfo, zipcode));
     }
   };
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,14 @@
+const apiKey = '9b9ce697dc74009c';
+const weatherURL = `https://api.wunderground.com/api/${apiKey}`;
+
+export const fetchLocationByZip = (zipcode) => {
+  let zipURL = `http://ZiptasticAPI.com/${zipcode}`;
+  return fetch(zipURL)
+    .then(response => response.json());
+};
+
+export const fetchLocationByPosition = (position) => {
+  let geoLocationURL = `${weatherURL}/geolookup/q/${position.coords.latitude},${position.coords.longitude}.json`;
+  return fetch(geoLocationURL)
+    .then(response => response.json());
+};

--- a/src/reducers/local-weather.js
+++ b/src/reducers/local-weather.js
@@ -1,7 +1,7 @@
 const localWeatherReducer = (state = {}, action) => {
   switch (action.type) {
 
-    case 'CURRENT_LOCAL_WEATHER_GPS':
+    case 'CURRENT_LOCAL_WEATHER':
       return Object.assign(action.currentLocalForecast.current_observation);
 
     default:

--- a/src/reducers/pinned-city-extended.js
+++ b/src/reducers/pinned-city-extended.js
@@ -2,7 +2,6 @@ const pinnedCityExtendedReducer = (state = [], action) => {
   switch (action.type) {
     
     case 'PINNED_CITY_EXTENDED_FORECAST':
-    debugger;
       return state.concat(action.payload);
 
     default:

--- a/src/reducers/pinned-city-extended.js
+++ b/src/reducers/pinned-city-extended.js
@@ -1,0 +1,13 @@
+const pinnedCityExtendedReducer = (state = [], action) => {
+  switch (action.type) {
+    
+    case 'PINNED_CITY_EXTENDED_FORECAST':
+    debugger;
+      return state.concat(action.payload);
+
+    default:
+      return state;
+  }
+};
+
+export default pinnedCityExtendedReducer;

--- a/src/reducers/pinned-city.js
+++ b/src/reducers/pinned-city.js
@@ -1,8 +1,9 @@
 const pinnedCityReducer = (state = [], action) => {
   switch (action.type) {
 
-      case 'PINNNED_CITY_CURRENT_WEATHER':
-        return state.concat(action.payload);
+    case 'PINNNED_CITY_CURRENT_WEATHER':
+      return state.concat(action.payload);
+
     default:
       return state;
   }

--- a/src/reducers/root-reducer.js
+++ b/src/reducers/root-reducer.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import localWeatherReducer from './local-weather';
 import extendedForecastReducer from './extended-forecast';
 import pinnedCityReducer from './pinned-city';
+import pinnedCityExtendedReducer from './pinned-city-extended';
 
 const rootReducer = combineReducers({
   localWeatherReducer,
   extendedForecastReducer,
-  pinnedCityReducer
+  pinnedCityReducer,
+  pinnedCityExtendedReducer
 });
 
 export default rootReducer;


### PR DESCRIPTION
## Purpose
The purpose of this PR is to get the extended forecast working for the pinned cities.  To do this we needed to refactor our action creators some to get the geolocation separated from the weather API calls.  

## Approach
Abstracted the geolocation functions out to a helpers.js file in the /src folder.  Those are imported in whatever components might need to make a weather call, we make 1 geolocation call to get city info and then pass that to our fetchCurrent and fetchExtended forecast actions.  That data is then passed down to the component to render current conditions on the home page and an extended forecast on the pinnedCityExtended page based on the dynamic route for that city.

## Pre Merge TODOs
None, this PR is ready to merge pending code review.  